### PR TITLE
Remove advanced flag from all config.yaml files

### DIFF
--- a/music_assistant/config.yaml
+++ b/music_assistant/config.yaml
@@ -24,7 +24,6 @@ map:
   - media:rw
   - ssl:ro
 init: false
-advanced: false
 backup_exclude:
   - cache.db
   - collage_images/*

--- a/music_assistant_beta/config.yaml
+++ b/music_assistant_beta/config.yaml
@@ -22,7 +22,6 @@ map:
   - media:rw
   - ssl:ro
 init: false
-advanced: false
 backup_exclude:
   - cache.db
   - collage_images/*

--- a/music_assistant_dev/config.yaml
+++ b/music_assistant_dev/config.yaml
@@ -24,7 +24,6 @@ map:
   - media:rw
   - ssl:ro
 init: false
-advanced: true
 stage: experimental
 tmpfs: true
 backup_exclude:

--- a/music_assistant_nightly/config.yaml
+++ b/music_assistant_nightly/config.yaml
@@ -23,7 +23,6 @@ map:
   - media:rw
   - ssl:ro
 init: false
-advanced: true
 backup_exclude:
   - cache.db
   - collage_images/*


### PR DESCRIPTION
The advanced flag is deprecated and ignored by latest versions of Supervisor, currently it only produces a warning that spam users' logs on each restart of Supervisor. Drop it from all app configs to avoid that.