### PR TITLE
Rename MA add-on -> MA App

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Music Assistant
 
 **Music Assistant**
 
-This is the Home Assistant add-on repository for Music Assistant for a convenient way to run the [Music Assistant Server](https://github.com/music-assistant/server)
+This is the Home Assistant App repository for Music Assistant for a convenient way to run the [Music Assistant Server](https://github.com/music-assistant/server)
 
 Music Assistant is a music library manager for your offline and online music sources, combined with the power of Home Assistant to easily stream your favourite music to a wide range of supported players.
 
@@ -16,10 +16,10 @@ For feature requests, please see [feature requests](https://github.com/music-ass
 
 ## Installation
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
+[![Open your Home Assistant instance and show the Add App repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
 
 
-If you want to do add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: https://github.com/music-assistant/home-assistant-addon
+If you want to add this repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: https://github.com/music-assistant/home-assistant-addon
 
 
 

--- a/music_assistant/README.md
+++ b/music_assistant/README.md
@@ -1,6 +1,6 @@
-# Music Assistant Add-on
+# Music Assistant App
 
-The official Music Assistant add-on for Home Assistant.
+The official Music Assistant App for Home Assistant.
 
 ## About Music Assistant
 
@@ -17,7 +17,7 @@ Music Assistant is a free, open-source music library manager that connects to yo
 
 ## Installation
 
-1. Navigate to **Settings** → **Add-ons** → **Add-on Store** in Home Assistant
+1. Navigate to **Settings** → **Apps** → **App Store** in Home Assistant
 2. Search for "Music Assistant"
 3. Click **Install**
 4. Wait for the installation to complete
@@ -57,7 +57,7 @@ When enabled, Music Assistant starts without loading any providers. This is usef
 
 ## Getting Started
 
-1. After starting the add-on, click **Open Web UI**
+1. After starting the App, click **Open Web UI**
 2. Follow the onboarding wizard to set up your first music provider
 3. Connect your speakers/players
 4. Start enjoying your music!
@@ -73,9 +73,9 @@ For advanced automation and control, you can optionally install the **Music Assi
 
 **To install the integration:**
 
-The Music Assistant server should be auto detected by Home Assistant onc eyou install the add-on (or any Music Assistant server in your network). On the Devices & services page, you should be greeted with a card for the discovered server to simply setup the integration.
+The Music Assistant server should be auto detected by Home Assistant once you install the App (or any Music Assistant server in your network). On the Devices & services page, you should be greeted with a card for the discovered server to simply set up the integration.
 
-**Note**: The add-on provides the Music Assistant server, while the integration provides the Home Assistant entities and automation capabilities. The add-on works perfectly fine without the integration if you only want to use the web interface.
+**Note**: The App provides the Music Assistant server, while the integration provides the Home Assistant entities and automation capabilities. The App works perfectly fine without the integration if you only want to use the web interface.
 
 ## Documentation
 
@@ -90,7 +90,7 @@ For detailed documentation, visit:
 
 If you encounter any issues:
 
-1. Check the add-on logs (available in the Home Assistant add-on page)
+1. Check the App logs (available in the Home Assistant App page)
 2. Visit the [documentation](https://music-assistant.io)
 3. Search existing issues at [music-assistant/support](https://github.com/music-assistant/support)
 4. Ask for help on [Discord](https://discord.gg/PZQ6RWbfeS) or [GitHub Discussions](https://github.com/orgs/music-assistant/discussions)
@@ -107,21 +107,21 @@ This is the **stable** channel. Updates are released after thorough testing and 
 
 ## Version Information
 
-This add-on uses stable releases of Music Assistant. For the latest features, consider the BETA or NIGHTLY versions (use at your own risk).
+This App uses stable releases of Music Assistant. For the latest features, consider the BETA or NIGHTLY versions (use at your own risk).
 
 ## Data Storage
 
-All Music Assistant data is stored within the add-on's data directory:
+All Music Assistant data is stored within the App's data directory:
 
 - Music library database
 - Configuration settings
 
-Making a backup of the Music Assistant add-on within Home Assistant will therefore also include your Music Assistant data. Please ensure to always make a backup before updating to a new version so you can always easily revert to the previous version!
+Making a backup of the Music Assistant App within Home Assistant will therefore also include your Music Assistant data. Please ensure to always make a backup before updating to a new version so you can always easily revert to the previous version!
 
 ## Performance Tips
 
 - Use a fast storage medium (SSD recommended)
-- Ensure adequate RAM (minimum 4GB for Home Assistant + this add-on)
+- Ensure adequate RAM (minimum 4GB for Home Assistant + this App)
 - Keep your Music Assistant instance updated
 
 ## Contributing

--- a/music_assistant_beta/README.md
+++ b/music_assistant_beta/README.md
@@ -1,4 +1,4 @@
-# Music Assistant (BETA) Add-on
+# Music Assistant (BETA) App
 
 The official BETA release channel for Music Assistant.
 
@@ -6,14 +6,14 @@ The official BETA release channel for Music Assistant.
 
 This is a **BETA** version of Music Assistant. It contains new features and improvements that are being tested before the stable release.
 
-**Use this add-on if you:**
+**Use this App if you:**
 
 - Want early access to new features
 - Are willing to help test and report issues
 - Can tolerate occasional bugs or instability
 - Want to contribute to making Music Assistant better
 
-**DO NOT use this add-on if you:**
+**DO NOT use this App if you:**
 
 - Need a stable, production-ready system at all times
 - Are not comfortable troubleshooting issues
@@ -43,7 +43,7 @@ As a BETA tester, your feedback is invaluable! Please report issues you encounte
 
 ### Before Reporting
 
-1. Check the add-on logs (enable `debug` logging if needed globally or on a per-provider level)
+1. Check the App logs (enable `debug` logging if needed globally or on a per-provider level)
 2. Search [existing issues](https://github.com/music-assistant/support)
 3. Verify the issue doesn't occur in the stable version if possible
 
@@ -52,7 +52,7 @@ As a BETA tester, your feedback is invaluable! Please report issues you encounte
 Include:
 
 - 📋 Steps to reproduce the issue
-- 📝 Full logs from the add-on (or download the full logfile from within MA's web interface)
+- 📝 Full logs from the App (or download the full logfile from within MA's web interface)
 - 🔢 Music Assistant version (visible in Web UI)
 - 🎵 Which music providers you're using
 - 🔊 Which players are affected
@@ -71,7 +71,7 @@ BETA releases are updated more frequently than stable releases. In general, more
 - Performance optimizations might still be in progress
 - You can not migrate from the stable version (and vice-versa)
 
-TIP: If you want to test the BETA version while keeping the stable version, simply stop the stable add-on and run the BETA add-on. Reverting back to stable is then as easy as stopping the BETA add-on again and starting stable. Bothg add-ons can not be activate at the same time.
+TIP: If you want to test the BETA version while keeping the stable version, simply stop the stable App and run the BETA App. Reverting back to stable is then as easy as stopping the BETA App again and starting stable. Both Apps cannot be active at the same time.
 
 ## Getting Help
 
@@ -92,13 +92,13 @@ Check the [CHANGELOG](CHANGELOG.md) for detailed information about what's new in
 4. **Be Patient**: Some features might not work perfectly
 5. **Stay Updated**: Install updates to get the latest fixes
 
-Making a backup of the Music Assistant add-on within Home Assistant will also include your Music Assistant data. Please ensure to always make a backup before updating to a new version so you can always easily revert to the previous version!
+Making a backup of the Music Assistant App within Home Assistant will also include your Music Assistant data. Please ensure to always make a backup before updating to a new version so you can always easily revert to the previous version!
 
 ## Rollback Strategy
 
 ### If Things Break
 
-1. **Stop the add-on**
+1. **Stop the App**
 2. **Restore from backup** (you made one, right?)
 3. **Report the issue**
 

--- a/music_assistant_dev/README.md
+++ b/music_assistant_dev/README.md
@@ -1,10 +1,10 @@
-# Music Assistant DEV Add-on
+# Music Assistant DEV App
 
-This is a special development add-on for Music Assistant that allows developers to quickly test specific branches, pull requests, or even forks of Music Assistant directly in Home Assistant.
+This is a special development App for Music Assistant that allows developers to quickly test specific branches, pull requests, or even forks of Music Assistant directly in Home Assistant.
 
 ## Purpose
 
-This add-on is designed for:
+This App is designed for:
 
 - Testing pull requests before merging
 - Developing and debugging new features
@@ -13,7 +13,7 @@ This add-on is designed for:
 
 ## How It Works
 
-Unlike the regular Music Assistant add-on which uses pre-built releases, this dev add-on:
+Unlike the regular Music Assistant App which uses pre-built releases, this Dev App:
 
 1. Builds and installs the server from a specified Git source (branch, PR, or fork)
 2. Builds and installs the frontend from a specified Git source (branch, PR, or fork)
@@ -71,7 +71,7 @@ server_repo: abc123def456...
 
 **Default**: `""` (empty - uses latest nightly release from GitHub)
 
-> **Note**: When `server_repo` is left empty or blank, the add-on will install the latest nightly release wheel from GitHub releases. This is the fastest option as no server build is required.
+> **Note**: When `server_repo` is left empty or blank, the App will install the latest nightly release wheel from GitHub releases. This is the fastest option as no server build is required.
 
 ### Frontend Repository Configuration
 
@@ -158,13 +158,13 @@ Build time varies depending on your configuration:
 
 ### Pull Request Syntax
 
-When specifying a pull request, use `pr-NUMBER` (e.g., `pr-123`, `pr-456`). The add-on will automatically fetch and checkout the PR for you.
+When specifying a pull request, use `pr-NUMBER` (e.g., `pr-123`, `pr-456`). The App will automatically fetch and checkout the PR for you.
 
 ## Troubleshooting
 
-### Add-on won't start
+### App won't start
 
-1. Check the add-on logs for build errors
+1. Check the App logs for build errors
 2. Verify the branch/PR/fork exists and is accessible
 3. Try using a known-good branch like `dev` or `main`
 4. Enable `safe_mode: true` to bypass provider loading
@@ -178,7 +178,7 @@ When specifying a pull request, use `pr-NUMBER` (e.g., `pr-123`, `pr-456`). The 
 ### Performance issues
 
 - Building from source uses more resources
-- Only use this add-on for development testing, not as a daily driver
+- Only use this App for development testing, not as a daily driver
 
 ## Developer Workflow
 
@@ -186,14 +186,14 @@ When specifying a pull request, use `pr-NUMBER` (e.g., `pr-123`, `pr-456`). The 
 
 1. Find the PR number (e.g., #456)
 2. Configure: `server_repo: pr-456`
-3. Restart the add-on
+3. Restart the App
 4. Test the changes
 
 ### Developing Features
 
 1. Push your branch to your fork
 2. Configure: `server_repo: yourusername/server@your-branch`
-3. Restart the add-on
+3. Restart the App
 4. Test and iterate
 
 ### Testing Both Server and Frontend Changes
@@ -209,14 +209,14 @@ This allows you to test coordinated changes across both repositories.
 
 This is a developer tool and is not supported for regular users. If you encounter issues:
 
-- Check the add-on logs
+- Check the App logs
 - Verify your Git references are correct
 - Test with the default branches first
 - Ask in the Music Assistant developer Discord channel
 
-## Differences from Regular Add-on
+## Differences from Regular App
 
-| Feature      | Regular Add-on    | DEV Add-on (Nightly mode) | DEV Add-on (Source mode) |
+| Feature      | Regular App       | DEV App (Nightly mode)    | DEV App (Source mode)    |
 | ------------ | ----------------- | ------------------------- | ------------------------ |
 | Installation | Pre-built release | Latest nightly wheel      | Built from source        |
 | Startup time | Fast              | Fast                      | Slower (build time)      |

--- a/music_assistant_dev/config.yaml
+++ b/music_assistant_dev/config.yaml
@@ -2,7 +2,7 @@ name: Music Assistant DEV SERVER
 # version number gets updated only when the mass base image updates!
 version: 1.4.10g
 slug: music_assistant_dev
-description: Development add-on for Music Assistant. For developers only.
+description: Development App for Music Assistant. For developers only.
 url: https://music-assistant.io
 arch:
   - amd64

--- a/music_assistant_dev/entrypoint.sh
+++ b/music_assistant_dev/entrypoint.sh
@@ -7,7 +7,7 @@ frontend_repo=$(cat /data/options.json | jq -r .frontend_repo)
 
 echo ""
 echo "-----------------------------------------------------------"
-echo "Music Assistant Developer Add-on"
+echo "Music Assistant Developer App"
 echo "-----------------------------------------------------------"
 echo ""
 
@@ -241,4 +241,3 @@ for path in /usr/lib/*/libjemalloc.so.2; do
 done
 # Start Music Assistant
 exec mass --data-dir /data --cache-dir /data/.cache
-

--- a/music_assistant_nightly/README.md
+++ b/music_assistant_nightly/README.md
@@ -1,4 +1,4 @@
-# Music Assistant (NIGHTLY) Add-on
+# Music Assistant (NIGHTLY) App
 
 Bleeding edge development builds of Music Assistant.
 
@@ -8,7 +8,7 @@ This is a **NIGHTLY** (development) version of Music Assistant. It contains the 
 
 ### 🔴 Critical Information
 
-**This add-on is:**
+**This App is:**
 
 - ❌ **NOT stable** - Can break at any time
 - ❌ **NOT tested** - Changes are pushed directly from development
@@ -76,7 +76,7 @@ NIGHTLY builds are automatic builds from the `dev` branch of Music Assistant. Th
 
 ### If Things Break
 
-1. **Stop the add-on**
+1. **Stop the App**
 2. **Restore from backup** (you made one, right?)
 3. **Report the issue**
 

--- a/ytm_po_token_generator/config.yaml
+++ b/ytm_po_token_generator/config.yaml
@@ -1,7 +1,7 @@
 name: YT Music PO Token Generator
 version: 1.3.1
 slug: ytm_po_token_generator
-description: A HA App wrapper for the BgUtils POT Provider that can generate PO tokens for Youtube Music.
+description: An HA App wrapper for the BgUtils POT Provider that can generate PO tokens for Youtube Music.
 url: https://github.com/Brainicism/bgutil-ytdlp-pot-provider
 image: brainicism/bgutil-ytdlp-pot-provider
 arch:

--- a/ytm_po_token_generator/config.yaml
+++ b/ytm_po_token_generator/config.yaml
@@ -1,7 +1,7 @@
 name: YT Music PO Token Generator
 version: 1.3.1
 slug: ytm_po_token_generator
-description: A HA addon wrapper for the BgUtils POT Provider that can generate PO tokens for Youtube Music.
+description: A HA App wrapper for the BgUtils POT Provider that can generate PO tokens for Youtube Music.
 url: https://github.com/Brainicism/bgutil-ytdlp-pot-provider
 image: brainicism/bgutil-ytdlp-pot-provider
 arch:


### PR DESCRIPTION
Music Assistant still uses the old terminology in its repository. Rename all documentation and user-facing occurrences of "add-ons" to "Apps".

Also fix some minor grammar nits encountered during the proof-reading.

Refs https://github.com/home-assistant/epics/issues/25