### PR TITLE
Add NetEase Cloud Music API add-on

### DIFF
--- a/netease_cloud_music_api/Dockerfile
+++ b/netease_cloud_music_api/Dockerfile
@@ -1,4 +1,5 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
+ARG NCM_API_REF=2c36daf07a4a092df3e5dc66f3acc9e1a9b4c91f
 FROM ${BUILD_FROM}
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
@@ -11,8 +12,8 @@ ENV HUSKY=0 \
     npm_config_ignore_scripts=1
 
 RUN git clone --depth=1 https://github.com/NeteaseCloudMusicApiEnhanced/api-enhanced.git . \
+    && git checkout ${NCM_API_REF} \
     && npm install --omit=dev --no-fund --no-audit \
-    && npm config delete ignore-scripts \
     && npm cache clean --force
 
 COPY rootfs /

--- a/netease_cloud_music_api/Dockerfile
+++ b/netease_cloud_music_api/Dockerfile
@@ -1,0 +1,24 @@
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
+FROM ${BUILD_FROM}
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN apk add --no-cache nodejs npm git
+
+WORKDIR /opt/netease-api
+
+ENV HUSKY=0 \
+    npm_config_ignore_scripts=1
+
+RUN git clone --depth=1 https://github.com/NeteaseCloudMusicApiEnhanced/api-enhanced.git . \
+    && npm install --omit=dev --no-fund --no-audit \
+    && npm config delete ignore-scripts \
+    && npm cache clean --force
+
+COPY rootfs /
+
+RUN chmod +x /run.sh
+
+EXPOSE 3000
+
+CMD ["/run.sh"]

--- a/netease_cloud_music_api/README.md
+++ b/netease_cloud_music_api/README.md
@@ -1,0 +1,9 @@
+# NetEase Cloud Music API
+
+This add-on runs NeteaseCloudMusicApiEnhanced as a local HTTP API service.
+
+Default endpoint:
+
+- `http://<home-assistant-host>:3000`
+
+Use this URL in the Music Assistant NetEase provider configuration.

--- a/netease_cloud_music_api/build.yaml
+++ b/netease_cloud_music_api/build.yaml
@@ -1,0 +1,11 @@
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
+  amd64: ghcr.io/home-assistant/amd64-base:3.20
+  armhf: ghcr.io/home-assistant/armhf-base:3.20
+  armv7: ghcr.io/home-assistant/armv7-base:3.20
+  i386: ghcr.io/home-assistant/i386-base:3.20
+labels:
+  org.opencontainers.image.title: "Home Assistant Add-on: NetEase Cloud Music API"
+  org.opencontainers.image.description: "Run NeteaseCloudMusicApiEnhanced API service for Music Assistant."
+  org.opencontainers.image.source: "https://github.com/xiasi0/ha-addon-netease-cloud-music-api"
+  org.opencontainers.image.licenses: "MIT"

--- a/netease_cloud_music_api/config.yaml
+++ b/netease_cloud_music_api/config.yaml
@@ -1,5 +1,5 @@
 name: NetEase Cloud Music API
-version: "0.1.0"
+version: "0.1.1"
 slug: netease_cloud_music_api
 description: NetEase Cloud Music API service for Music Assistant.
 url: https://github.com/NeteaseCloudMusicApiEnhanced/api-enhanced
@@ -16,9 +16,3 @@ ports:
   3000/tcp: 3000
 ports_description:
   3000/tcp: NetEase API HTTP
-options:
-  port: 3000
-  host: ""
-schema:
-  port: "port"
-  host: "str?"

--- a/netease_cloud_music_api/config.yaml
+++ b/netease_cloud_music_api/config.yaml
@@ -1,0 +1,24 @@
+name: NetEase Cloud Music API
+version: "0.1.0"
+slug: netease_cloud_music_api
+description: NetEase Cloud Music API service for Music Assistant.
+url: https://github.com/NeteaseCloudMusicApiEnhanced/api-enhanced
+startup: services
+boot: auto
+init: false
+arch:
+  - aarch64
+  - amd64
+  - armhf
+  - armv7
+  - i386
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: NetEase API HTTP
+options:
+  port: 3000
+  host: ""
+schema:
+  port: "port"
+  host: "str?"

--- a/netease_cloud_music_api/rootfs/run.sh
+++ b/netease_cloud_music_api/rootfs/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/with-contenv bashio
+set -euo pipefail
+
+PORT="$(bashio::config 'port')"
+HOST="$(bashio::config 'host')"
+
+export NODE_ENV=production
+export PORT
+
+if [ -n "${HOST}" ]; then
+  export HOST
+fi
+
+bashio::log.info "Starting NetEase Cloud Music API on ${HOST:-0.0.0.0}:${PORT}"
+
+cd /opt/netease-api
+exec npm run start

--- a/netease_cloud_music_api/rootfs/run.sh
+++ b/netease_cloud_music_api/rootfs/run.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/with-contenv bashio
 set -euo pipefail
 
-PORT="$(bashio::config 'port')"
-HOST="$(bashio::config 'host')"
-
 export NODE_ENV=production
-export PORT
+export PORT=3000
 
-if [ -n "${HOST}" ]; then
-  export HOST
-fi
-
-bashio::log.info "Starting NetEase Cloud Music API on ${HOST:-0.0.0.0}:${PORT}"
+bashio::log.info "Starting NetEase Cloud Music API on 0.0.0.0:${PORT}"
 
 cd /opt/netease-api
 exec npm run start


### PR DESCRIPTION
## Summary
Add a Home Assistant add-on that runs NeteaseCloudMusicApiEnhanced as a local HTTP service so Music Assistant can integrate NetEase Cloud Music.

## Why this add-on is needed
The NetEase Cloud Music provider in Music Assistant relies on a local API service for authentication and playback metadata. Shipping this as a Supervisor add-on makes setup consistent and avoids requiring users to run a separate Node service manually.

## Risks / considerations
- This add-on wraps an unofficial API service (NeteaseCloudMusicApiEnhanced). The upstream API can change or become unavailable without notice.
- Users must have valid NetEase Cloud Music accounts/subscriptions for full-quality playback. No unlocking or bypass of restricted content is performed.
- The add-on exposes a local HTTP API intended for LAN use only.

## Related
- Music Assistant provider PR: https://github.com/music-assistant/server/pull/3640