### PR TITLE
Fix USB soundcard access for Local Audio Out provider

### DIFF
--- a/music_assistant/apparmor.txt
+++ b/music_assistant/apparmor.txt
@@ -22,6 +22,8 @@ profile music_assistant_addon flags=(attach_disconnected,mediate_deleted) {
 
   /dev/* mrwkl,
   /tmp/** mrkwl,
+  /dev/snd/ rw,
+  /dev/snd/** rw,
 
   # Data access
   /data/** rw,

--- a/music_assistant/config.yaml
+++ b/music_assistant/config.yaml
@@ -15,6 +15,7 @@ auth_api: true
 host_network: true
 ingress: true
 ingress_port: 8094
+audio: true
 panel_icon: mdi:music-assistant
 panel_title: Music Assistant
 panel_admin: false

--- a/music_assistant_beta/apparmor.txt
+++ b/music_assistant_beta/apparmor.txt
@@ -22,6 +22,8 @@ profile music_assistant_addon flags=(attach_disconnected,mediate_deleted) {
 
   /dev/* mrwkl,
   /tmp/** mrkwl,
+  /dev/snd/ rw,
+  /dev/snd/** rw,
 
   # Data access
   /data/** rw,

--- a/music_assistant_beta/config.yaml
+++ b/music_assistant_beta/config.yaml
@@ -13,6 +13,7 @@ auth_api: true
 host_network: true
 ingress: true
 ingress_port: 8094
+audio: true
 panel_icon: mdi:music-assistant
 panel_title: Music Assistant
 panel_admin: false

--- a/music_assistant_nightly/apparmor.txt
+++ b/music_assistant_nightly/apparmor.txt
@@ -22,6 +22,8 @@ profile music_assistant_addon flags=(attach_disconnected,mediate_deleted) {
 
   /dev/* mrwkl,
   /tmp/** mrkwl,
+  /dev/snd/ rw,
+  /dev/snd/** rw,
 
   # Data access
   /data/** rw,

--- a/music_assistant_nightly/config.yaml
+++ b/music_assistant_nightly/config.yaml
@@ -15,6 +15,7 @@ auth_api: true
 host_network: true
 ingress: true
 ingress_port: 8094
+audio: true
 panel_icon: mdi:music-assistant
 panel_title: Music Assistant
 panel_admin: false


### PR DESCRIPTION
This has been tested on the dev server for a little while and two different users advised it resolved their inability to use their USB audio devices so rolling this out to all the builds.