### PR TITLE
Bump the version of node used in the DEV server app

### DIFF
--- a/music_assistant_dev/Dockerfile
+++ b/music_assistant_dev/Dockerfile
@@ -14,10 +14,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends jq htop git curl ca-certificates gnupg libportaudio2 libasound2-plugins dbus && \
-  # Install Node.js 20.x from NodeSource
+  # Install Node.js 22.x from NodeSource
   mkdir -p /etc/apt/keyrings && \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends nodejs && \
   npm install -g yarn && \


### PR DESCRIPTION
Needed to support the new version of intlify used in the frontend repo as of commit [31f00ba65](https://github.com/music-assistant/frontend/commit/31f00ba65e81f4768b103956600a4b598f65b1cd) by dependabot.

Without this, dev builds with the frontend repo fail with:

```
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error @intlify/shared@11.4.4: The engine "node" is incompatible with this module. Expected version ">= 22". Got "20.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Tested by building the docker image locally and ensuring it does pull in node 22.x.