### PR TITLE
Bump Node.js to 22.x in dev add-on

### DIFF
--- a/music_assistant_dev/Dockerfile
+++ b/music_assistant_dev/Dockerfile
@@ -14,10 +14,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends jq htop git curl ca-certificates gnupg libportaudio2 libasound2-plugins dbus && \
-  # Install Node.js 20.x from NodeSource
+  # Install Node.js 22.x from NodeSource
   mkdir -p /etc/apt/keyrings && \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends nodejs && \
   npm install -g yarn && \


### PR DESCRIPTION
## Summary

Frontend `main` (since [#1794](https://github.com/music-assistant/frontend/pull/1794)) depends on `vue-i18n@11.4.4`, which pulls in `@intlify/shared@11.4.4` with `engines.node: ">= 22"`. The dev add-on's `yarn install --frozen-lockfile` step in `entrypoint.sh` fails with:

```
error @intlify/shared@11.4.4: The engine "node" is incompatible with this module. Expected version ">= 22". Got "20.20.2"
error Found incompatible module.
```

This blocks any from-source frontend build off the current frontend `main` — every user with `frontend_repo` set in the add-on options hits this.

## Change

`music_assistant_dev/Dockerfile`: bump the NodeSource `node_20.x` repo to `node_22.x`. This matches what frontend CI (`test.yml`, `release.yml`) already targets via `NODE_VERSION: "22.x"`.

Other variants (`music_assistant`, `music_assistant_beta`, `music_assistant_nightly`) don't have a Dockerfile — they ship the prebuilt frontend wheel — so they're unaffected.

## Test plan

- [ ] Build `music_assistant_dev` image locally: `docker build music_assistant_dev` succeeds
- [ ] With `frontend_repo` set to e.g. `music-assistant/frontend@main`, the add-on starts cleanly, completing "Step 2: Building and Installing Music Assistant Frontend" without the engine-incompatibility error
- [ ] With `frontend_repo` left empty (default), nightly-bundled frontend still loads (Step 2 is skipped, unaffected by the Node bump)